### PR TITLE
feat(entities): add expose/unexpose entity tools

### DIFF
--- a/src/ha-client.ts
+++ b/src/ha-client.ts
@@ -96,6 +96,21 @@ export class HAClient {
     return response.data;
   }
 
+  async listExposedEntities(assistant?: string): Promise<any> {
+    const params = assistant ? { assistant } : {};
+    const response = await this.client.get(`/api/entities/exposed`, { params });
+    return response.data;
+  }
+
+  async exposeEntities(entityIds: string[], shouldExpose?: boolean, assistant?: string): Promise<any> {
+    const response = await this.client.post(`/api/entities/expose`, {
+      entity_ids: entityIds,
+      should_expose: shouldExpose ?? true,
+      assistant: assistant ?? 'conversation',
+    });
+    return response.data;
+  }
+
   // Entity Registry API
   async getEntityRegistryList(): Promise<any[]> {
     const response = await this.client.get(`/api/registries/entities/list`);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -196,6 +196,16 @@ export const toolHandlers: Record<string, ToolHandler> = {
     return jsonResponse(result);
   },
 
+  'ha_list_exposed_entities': async (client, args) => {
+    const result = await client.listExposedEntities(args.assistant);
+    return jsonResponse(result);
+  },
+
+  'ha_expose_entities': async (client, args) => {
+    const result = await client.exposeEntities(args.entity_ids, args.should_expose, args.assistant);
+    return jsonResponse(result);
+  },
+
   // Entity Registry Operations
   'ha_get_entity_registry': async (client, args) => {
     const result = await client.getEntityRegistryList();

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -135,6 +135,42 @@ export const tools: Tool[] = [
       required: ['old_entity_id', 'new_entity_id'],
     },
   },
+  {
+    name: 'ha_list_exposed_entities',
+    description: '[READ-ONLY] List entities exposed to a voice assistant (Assist/Ollama, Alexa, Google Assistant). Safe operation - only reads data. Use to check which entities are available for voice control.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        assistant: {
+          type: 'string',
+          description: 'Assistant name: "conversation" (Assist/Ollama, default), "cloud.alexa", or "cloud.google_assistant"',
+        },
+      },
+    },
+  },
+  {
+    name: 'ha_expose_entities',
+    description: '[WRITE] Expose or unexpose entities to a voice assistant. MODIFIES voice assistant configuration - requires approval. Changes take effect immediately (no HA restart needed).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entity_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of entity IDs to expose or unexpose (e.g., ["light.kitchen", "sensor.temperature"])',
+        },
+        should_expose: {
+          type: 'boolean',
+          description: 'True to expose, False to unexpose (default: true)',
+        },
+        assistant: {
+          type: 'string',
+          description: 'Assistant name: "conversation" (default), "cloud.alexa", or "cloud.google_assistant"',
+        },
+      },
+      required: ['entity_ids'],
+    },
+  },
 
   // Entity Registry Operations
   {


### PR DESCRIPTION
## Summary

- Add `ha_list_exposed_entities` tool to list entities exposed to a voice assistant (Assist/Ollama, Alexa, Google Assistant)
- Add `ha_expose_entities` tool to expose or unexpose entities to a voice assistant
- Both tools require matching backend endpoints (`GET /api/entities/exposed`, `POST /api/entities/expose`) from [home-assistant-vibecode-agent PR #29](https://github.com/Coolver/home-assistant-vibecode-agent/pull/29)

## Changes

| File | Description |
|------|-------------|
| `src/tools.ts` | 2 new tool definitions with input schemas |
| `src/handlers.ts` | 2 handler entries routing to client methods |
| `src/ha-client.ts` | 2 client methods (`listExposedEntities`, `exposeEntities`) |

## Dependencies

This PR depends on the backend PR [Coolver/home-assistant-vibecode-agent#29](https://github.com/Coolver/home-assistant-vibecode-agent/pull/29) which adds the corresponding API endpoints.

## Test plan

- [ ] `ha_list_exposed_entities` returns list of exposed entities for default assistant
- [ ] `ha_list_exposed_entities` with `assistant: "cloud.alexa"` filters correctly
- [ ] `ha_expose_entities` with entity_ids exposes entities successfully
- [ ] `ha_expose_entities` with `should_expose: false` unexposes entities